### PR TITLE
Remove enclosing Option during xml transformation

### DIFF
--- a/app/uk/gov/hmrc/taxfraudreporting/services/XmlFactory.scala
+++ b/app/uk/gov/hmrc/taxfraudreporting/services/XmlFactory.scala
@@ -72,7 +72,7 @@ class XmlFactory @Inject() (val configuration: Configuration) extends Configured
       <valueFraudBand>{valueFraudBand}</valueFraudBand>
       <durationFraud>{fraudReportBody.durationFraud.orNull}</durationFraud>
       <howManyKnow>{fraudReportBody.howManyKnow.orNull}</howManyKnow>
-      <additionalDetails>{fraudReportBody.additionalDetails}</additionalDetails>
+      <additionalDetails>{fraudReportBody.additionalDetails.orNull}</additionalDetails>
       {fraudReportBody.reporter map { _.toXml } orNull}
       <supportingEvidence>{fraudReportBody.hasEvidence}</supportingEvidence>
       {


### PR DESCRIPTION
Without the fix, xml  has `Some`
![image](https://user-images.githubusercontent.com/98329769/158369917-a1e0d2ba-c25e-4beb-888c-4fe5938df6e9.png)

After the fix
![image](https://user-images.githubusercontent.com/98329769/158370043-a7d62fb2-18f2-416c-b618-70b30e3cfb81.png)
